### PR TITLE
updated catkin buildtool_depend

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
 
   <author>Chad Rockey</author>
 
+  <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>gtest</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
This will need to be re-released to build properly against groovy.
