### PR TITLE
Fix testdeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,0 @@
-include $(shell rospack find mk)/cmake.mk

--- a/package.xml
+++ b/package.xml
@@ -27,11 +27,6 @@
   <run_depend>image_transport</run_depend>
   <run_depend>image_geometry</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
-  <test_depend>sensor_msgs</test_depend>
-  <test_depend>nodelet</test_depend>
-  <test_depend>image_transport</test_depend>
-  <test_depend>image_geometry</test_depend>
-  <test_depend>dynamic_reconfigure</test_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelets.xml"/>


### PR DESCRIPTION
Remove redundant test dependencies; this prevents new tools from spewing warnings when they parse the package.xml.

Also remove the Makefile; it's old and no longer necessary.
