### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,11 @@ target_link_libraries(DepthImageToLaserScanNodelet DepthImageToLaserScanROS ${ca
 add_executable(depthimage_to_laserscan src/depthimage_to_laserscan.cpp)
 target_link_libraries(depthimage_to_laserscan DepthImageToLaserScanROS ${catkin_LIBRARIES})
 
-# Test the library
-catkin_add_gtest(libtest test/DepthImageToLaserScanTest.cpp)
-target_link_libraries(libtest DepthImageToLaserScan ${catkin_LIBRARIES})
+if(CATKIN_ENABLE_TESTING)
+  # Test the library
+  catkin_add_gtest(libtest test/DepthImageToLaserScanTest.cpp)
+  target_link_libraries(libtest DepthImageToLaserScan ${catkin_LIBRARIES})
+endif()
 
 # add the test executable, keep it from being built by "make all"
 add_executable(test_dtl EXCLUDE_FROM_ALL test/depthimage_to_laserscan_rostest.cpp)

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
 
   <author>Chad Rockey</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
   <build_depend>gtest</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
