### PR TITLE
Add max_range heuristics for the Kinect

### DIFF
--- a/cfg/Depth.cfg
+++ b/cfg/Depth.cfg
@@ -13,5 +13,6 @@ gen.add("scan_time",            double_t, 0,                                "Tim
 gen.add("range_min",            double_t, 0,                                "Minimum reported range (in meters).",                              0.45,   0.0, 10.0)
 gen.add("range_max",            double_t, 0,                                "Maximum reported range (in meters).",                              10.0,   0.0, 10.0)
 gen.add("output_frame_id",      str_t,    0,                                "Output frame_id for the laserscan.",   "camera_depth_frame")
+gen.add("kinect_heuristics",    bool_t,   0,                                "Enable range_max heuristics for kinect",   False)
 
 exit(gen.generate(PACKAGE, "depthimage_to_laserscan", "Depth"))

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -160,3 +160,7 @@ void DepthImageToLaserScan::set_scan_height(const int scan_height){
 void DepthImageToLaserScan::set_output_frame(const std::string output_frame_id){
   output_frame_id_ = output_frame_id;
 }
+
+void DepthImageToLaserScan::set_kinect_heuristics(const bool kinect_heuristics){
+  use_kinect_heuristics_ = kinect_heuristics;
+}

--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -88,4 +88,5 @@ void DepthImageToLaserScanROS::reconfigureCb(depthimage_to_laserscan::DepthConfi
     dtl_.set_range_limits(config.range_min, config.range_max);
     dtl_.set_scan_height(config.scan_height);
     dtl_.set_output_frame(config.output_frame_id);
+    dtl_.set_kinect_heuristics(config.kinect_heuristics);
 }


### PR DESCRIPTION
This patch implements a way to convert out-of-range readings from the kinect into usable maximum-range readings.  The current implementation cannot tell the difference between too close and too far readings, marking them both as NaN.  This causes problems with large spaces like hallways where we have readings to the left and right but nothing in the middle.  This is most apparent when running SLAM as you get wedges of unexplored region instead of it being marked empty.

**Gmapping without the heuristics in a long hallway:**
![without_heuristics](https://cloud.githubusercontent.com/assets/2602827/2769697/ec612164-ca54-11e3-8957-cfd4a2f91afa.png)

**With heuristics turned on (robot was not moved)**
![with_heuristics](https://cloud.githubusercontent.com/assets/2602827/2769696/ec6127c2-ca54-11e3-8093-53f1a77af65e.png)

This works by examining the readings to the left and right of a section of out of range readings.  If these are greater than half the max range we assume that the out of range readings are due to being too far away rather than too close.  A number of other heuristics are applied in an attempt to reduce false positives.  This patch is not perfect but it definitely takes are lot of the pain out of mapping large spaces.

Its most apparent failure I've noticed is when it gets too close to sharp edges, it might mistake the too-close readings depending on what it can see on the other side of the edge.  Still, the errors don't impact the map that much and this can be controlled by reducing the range_max setting both in this package and in gmapping.
