### PR TITLE
Improving performance for ARM7-based platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ target_link_libraries(DepthImageToLaserScanNodelet DepthImageToLaserScanROS ${ca
 add_executable(depthimage_to_laserscan src/depthimage_to_laserscan.cpp)
 target_link_libraries(depthimage_to_laserscan DepthImageToLaserScanROS ${catkin_LIBRARIES})
 
+add_executable(depthimage_to_laserscan_test src/DepthImageToLaserScanROS_test.cpp)
+target_link_libraries(depthimage_to_laserscan_test DepthImageToLaserScan ${catkin_LIBRARIES})
+
 if(CATKIN_ENABLE_TESTING)
   # Test the library
   catkin_add_gtest(libtest test/DepthImageToLaserScanTest.cpp)

--- a/include/depthimage_to_laserscan/DepthImageToLaserScan.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScan.h
@@ -64,44 +64,36 @@ namespace depthimage_to_laserscan
      * 
      */
     sensor_msgs::LaserScanPtr convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
-    	      const sensor_msgs::CameraInfoConstPtr& info_msg)
-    {
-    	sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
-    	convert_msg(depth_msg, info_msg, scan_msg);
-    	return scan_msg;
-    }
+    	      const sensor_msgs::CameraInfoConstPtr& info_msg);
 
     /**
      * Allocation-free converter
      */
     bool convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
-					   const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg);
-    
+		     const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg);
+
 
     /**
-	 * Converts the information in a depth image (sensor_msgs::Image) to a sensor_msgs::LaserScan.
-	 *
-	 * This function converts the information in the depth encoded image (UInt16 or Float32 encoding) into
-	 * a sensor_msgs::LaserScan as accurately as possible.  To do this, it requires the synchornized Image/CameraInfo
-	 * pair associated with the image.
-	 *
-	 * This function uses float32 for most calculations. ARM/NEON platforms prefer float over double
-	 *
-	 * @param depth_msg UInt16 or Float32 encoded depth image.
-	 * @param info_msg CameraInfo associated with depth_msg
-	 * @return sensor_msgs::LaserScanPtr for the center row(s) of the depth image.
-	 *
-	 */
+     * Converts the information in a depth image (sensor_msgs::Image) to a sensor_msgs::LaserScan.
+     *
+     * This function converts the information in the depth encoded image (UInt16 or Float32 encoding) into
+     * a sensor_msgs::LaserScan as accurately as possible.  To do this, it requires the synchornized Image/CameraInfo
+     * pair associated with the image.
+     *
+     * This function uses float32 for most calculations. ARM/NEON platforms prefer float over double
+     *
+     * @param depth_msg UInt16 or Float32 encoded depth image.
+     * @param info_msg CameraInfo associated with depth_msg
+     * @return sensor_msgs::LaserScanPtr for the center row(s) of the depth image.
+     *
+     */
     sensor_msgs::LaserScanPtr convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
-        	      const sensor_msgs::CameraInfoConstPtr& info_msg)
-	{
-		sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
-		convert_msg_f(depth_msg, info_msg, scan_msg);
-		return scan_msg;
-	}
-
-	bool convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
-					   const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg);
+					    const sensor_msgs::CameraInfoConstPtr& info_msg);
+    /**
+     * Allocation-free converter for float version
+     */
+    bool convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
+		       const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg);
 
     /**
      * Sets the scan time parameter.
@@ -163,15 +155,15 @@ namespace depthimage_to_laserscan
     double magnitude_of_ray(const cv::Point3d& ray) const;
 
     /**
-	 * Computes euclidean length of a cv::Point3f (as a ray from origin)
-	 *
-	 * This function computes the length of a cv::Point3f assumed to be a vector starting at the origin (0,0,0).
-	 *
-	 * @param ray The ray for which the magnitude is desired.
-	 * @return Returns the magnitude of the ray.
-	 *
-	 */
-	float magnitude_of_ray_f(const cv::Point3f& ray) const;
+     * Computes euclidean length of a cv::Point3f (as a ray from origin)
+     *
+     * This function computes the length of a cv::Point3f assumed to be a vector starting at the origin (0,0,0).
+     *
+     * @param ray The ray for which the magnitude is desired.
+     * @return Returns the magnitude of the ray.
+     *
+     */
+    float magnitude_of_ray_f(const cv::Point3f& ray) const;
 
     /**
      * Computes the angle between two cv::Point3d
@@ -187,18 +179,18 @@ namespace depthimage_to_laserscan
     double angle_between_rays(const cv::Point3d& ray1, const cv::Point3d& ray2) const;
 
     /**
-	 * Computes the angle between two cv::Point3f
-	 *
-	 * Computes the angle of two cv::Point3f assumed to be vectors starting at the origin (0,0,0).
-	 * Uses the following equation: angle = arccos(a*b/(|a||b|)) where a = ray1 and b = ray2.
-	 *
-	 * @param ray1 The first ray
-	 * @param ray2 The second ray
-	 * @return The angle between the two rays (in radians)
-	 *
-	 */
+     * Computes the angle between two cv::Point3f
+     *
+     * Computes the angle of two cv::Point3f assumed to be vectors starting at the origin (0,0,0).
+     * Uses the following equation: angle = arccos(a*b/(|a||b|)) where a = ray1 and b = ray2.
+     *
+     * @param ray1 The first ray
+     * @param ray2 The second ray
+     * @return The angle between the two rays (in radians)
+     *
+     */
     float angle_between_rays_f(const cv::Point3f& ray1, const cv::Point3f& ray2) const;
-    
+
     /**
      * Determines whether or not new_value should replace old_value in the LaserScan.
      * 
@@ -229,7 +221,7 @@ namespace depthimage_to_laserscan
     */
     template<typename T>
     void convert(const sensor_msgs::ImageConstPtr& depth_msg, const image_geometry::PinholeCameraModel& cam_model, 
-		 const sensor_msgs::LaserScanPtr& scan_msg, const int& scan_height) const{
+        const sensor_msgs::LaserScanPtr& scan_msg, const int& scan_height) const{
       // Use correct principal point from calibration
       float center_x = cam_model.cx();
       float center_y = cam_model.cy();
@@ -238,7 +230,7 @@ namespace depthimage_to_laserscan
       double unit_scaling = depthimage_to_laserscan::DepthTraits<T>::toMeters( T(1) );
       float constant_x = unit_scaling / cam_model.fx();
       float constant_y = unit_scaling / cam_model.fy();
-      
+
       const T* depth_row = reinterpret_cast<const T*>(&depth_msg->data[0]);
       int row_step = depth_msg->step / sizeof(T);
 
@@ -247,94 +239,93 @@ namespace depthimage_to_laserscan
 
       for(int v = offset; v < offset+scan_height_; v++, depth_row += row_step)
       {
-		for (int u = 0; u < (int)depth_msg->width; u++) // Loop over each pixel in row
-		{	
-		  T depth = depth_row[u];
-		  
-		  double r = depth; // Assign to pass through NaNs and Infs
-		  double th = -atan2((double)(u - center_x) * constant_x, unit_scaling); // Atan2(x, z), but depth divides out
-		  int index = (th - scan_msg->angle_min) / scan_msg->angle_increment;
-		  
-		  if (depthimage_to_laserscan::DepthTraits<T>::valid(depth)){ // Not NaN or Inf
-		    // Calculate in XYZ
-		    double x = (u - center_x) * depth * constant_x;
-		    double z = depthimage_to_laserscan::DepthTraits<T>::toMeters(depth);
-		    
-		    // Calculate actual distance
-		    r = sqrt(pow(x, 2.0) + pow(z, 2.0));
-		  }
-	  
-	  // Determine if this point should be used.
-	  if(use_point(r, scan_msg->ranges[index], scan_msg->range_min, scan_msg->range_max)){
-	    scan_msg->ranges[index] = r;
-	  }
-	}
+        for (int u = 0; u < (int)depth_msg->width; u++) // Loop over each pixel in row
+        {
+          T depth = depth_row[u];
+
+          double r = depth; // Assign to pass through NaNs and Infs
+          double th = -atan2((double)(u - center_x) * constant_x, unit_scaling); // Atan2(x, z), but depth divides out
+          int index = (th - scan_msg->angle_min) / scan_msg->angle_increment;
+
+          if (depthimage_to_laserscan::DepthTraits<T>::valid(depth)){ // Not NaN or Inf
+            // Calculate in XYZ
+            double x = (u - center_x) * depth * constant_x;
+            double z = depthimage_to_laserscan::DepthTraits<T>::toMeters(depth);
+
+            // Calculate actual distance
+            r = sqrt(pow(x, 2.0) + pow(z, 2.0));
+          }
+
+          // Determine if this point should be used.
+          if(use_point(r, scan_msg->ranges[index], scan_msg->range_min, scan_msg->range_max)){
+            scan_msg->ranges[index] = r;
+          }
+        }
       }
     }
     
-    // Optimized version
-    // 1. Using float instead of double
-    // 2. Column-order processing
-    // 3. No shared_ptr interaction for each pixel
+    /** Optimized version of 'convert' function
+     * 1. Using float instead of double
+     * 2. Column-order processing
+     * 3. No shared_ptr interaction for each pixel
+     */
     template<typename T>
-	void convert_f(const sensor_msgs::ImageConstPtr& depth_msg, const image_geometry::PinholeCameraModel& cam_model,
-		 const sensor_msgs::LaserScanPtr& scan_msg, const int& scan_height) const{
-	  // Use correct principal point from calibration
-	  float center_x = cam_model.cx();
-	  float center_y = cam_model.cy();
+    void convert_f(const sensor_msgs::ImageConstPtr& depth_msg, const image_geometry::PinholeCameraModel& cam_model,
+        const sensor_msgs::LaserScanPtr& scan_msg, const int& scan_height) const{
+      // Use correct principal point from calibration
+      float center_x = cam_model.cx();
+      float center_y = cam_model.cy();
 
-	  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-	  float unit_scaling = depthimage_to_laserscan::DepthTraits<T>::toMeters( T(1) );
-	  float constant_x = unit_scaling / cam_model.fx();
-	  float constant_y = unit_scaling / cam_model.fy();
+      // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
+      float unit_scaling = depthimage_to_laserscan::DepthTraits<T>::toMeters( T(1) );
+      float constant_x = unit_scaling / cam_model.fx();
+      float constant_y = unit_scaling / cam_model.fy();
 
-	  //const T* depth_row = reinterpret_cast<const T*>(&depth_msg->data[0]);
-	  const T* depth_col = reinterpret_cast<const T*>(&depth_msg->data[0]);
-	  int row_step = depth_msg->step / sizeof(T);
+      const T* depth_col = reinterpret_cast<const T*>(&depth_msg->data[0]);
+      int row_step = depth_msg->step / sizeof(T);
 
-	  int offset = (int)(cam_model.cy()-scan_height/2);
-	  //depth_row += offset*row_step; // Offset to center of image
-	  depth_col += offset*row_step;	// Offset to center of image
+      int offset = (int)(cam_model.cy()-scan_height/2);
+      depth_col += offset*row_step;	// Offset to center of image
 
-	  sensor_msgs::LaserScan &scan = *scan_msg;
+      sensor_msgs::LaserScan &scan = *scan_msg;
 
-	  // Row order iteration (Y->X) is not effective here, because of atan2 calculation
-	  for (int u = 0; u < (int)depth_msg->width; u++, depth_col++) // Loop over each pixel in row
-	  {
-		// This can be precomputed for each column until sensor geometry is not changing
-		float th = -atan2f((float)(u - center_x) * constant_x, unit_scaling); // Atan2(x, z), but depth divides out
-		int index = (th - scan_msg->angle_min) / scan_msg->angle_increment;
-		const T* ptr = depth_col;
+      // Row order iteration (Y->X) is not effective here, because of atan2 calculation
+      for (int u = 0; u < (int)depth_msg->width; u++, depth_col++) // Loop over each pixel in row
+      {
+        // This can be precomputed for each column until sensor geometry is not changing
+        float th = -atan2f((float)(u - center_x) * constant_x, unit_scaling); // Atan2(x, z), but depth divides out
+        int index = (th - scan_msg->angle_min) / scan_msg->angle_increment;
+        const T* ptr = depth_col;
 
-		float min_range = scan.range_max*scan.range_max;
+        float min_range = scan.range_max*scan.range_max;
 
-		for(int v = offset; v < offset+scan_height_; v++, ptr += row_step)
-		{
-		  T depth = *ptr;
+        for(int v = offset; v < offset+scan_height_; v++, ptr += row_step)
+        {
+          T depth = *ptr;
 
-		  float r = depth; // Assign to pass through NaNs and Infs
+          float r = depth; // Assign to pass through NaNs and Infs
 
-		  if (depthimage_to_laserscan::DepthTraits<T>::valid(depth)){ // Not NaN or Inf
-			// Calculate in XYZ
-			float x = (u - center_x) * depth * constant_x;
-			float z = depthimage_to_laserscan::DepthTraits<T>::toMeters(depth);
-			// Calculate actual distance
-			r = x*x + z*z;
-			if( r < min_range)
-				min_range = r;
-		  }
-		}
-		float r = sqrt(min_range);
-		// Determine if this point should be used.
-	    if(use_point(r, scan.ranges[index], scan.range_min, scan.range_max))
-	    {
-		  scan.ranges[index] = r;
-	    }
-	  }
-	}
+          if (depthimage_to_laserscan::DepthTraits<T>::valid(depth)){ // Not NaN or Inf
+            // Calculate in XYZ
+            float x = (u - center_x) * depth * constant_x;
+            float z = depthimage_to_laserscan::DepthTraits<T>::toMeters(depth);
+            // Calculate actual distance
+            r = x*x + z*z;
+            if( r < min_range)
+              min_range = r;
+          }
+        }
+        float r = sqrt(min_range);
+        // Determine if this point should be used.
+        if(use_point(r, scan.ranges[index], scan.range_min, scan.range_max))
+        {
+          scan.ranges[index] = r;
+        }
+      }
+    }
 
     image_geometry::PinholeCameraModel cam_model_; ///< image_geometry helper class for managing sensor_msgs/CameraInfo messages.
-    
+
     float scan_time_; ///< Stores the time between scans.
     float range_min_; ///< Stores the current minimum range to use.
     float range_max_; ///< Stores the current maximum range to use.

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS_test.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS_test.h
@@ -46,12 +46,12 @@
 
 namespace depthimage_to_laserscan
 { 
-  class DepthImageToLaserScanROS
+  class DepthImageToLaserScanROSTest
   {
   public:
-    DepthImageToLaserScanROS(ros::NodeHandle& n, ros::NodeHandle& pnh);
+	  DepthImageToLaserScanROSTest(ros::NodeHandle& n, ros::NodeHandle& pnh);
     
-    ~DepthImageToLaserScanROS();
+    ~DepthImageToLaserScanROSTest();
 
   private:
     /**
@@ -97,6 +97,7 @@ namespace depthimage_to_laserscan
     image_transport::ImageTransport it_; ///< Subscribes to synchronized Image CameraInfo pairs.
     image_transport::CameraSubscriber sub_; ///< Subscriber for image_transport
     ros::Publisher pub_; ///< Publisher for output LaserScan messages
+    ros::Publisher pub_test_; ///< Publisher for output LaserScan messages
     dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig> srv_; ///< Dynamic reconfigure server
     
     depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -103,7 +103,7 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
   return scan_msg;
 }
 
-sensor_msgs::LaserScanPtr convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
+sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
 					const sensor_msgs::CameraInfoConstPtr& info_msg)
 {
   sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -95,6 +95,22 @@ bool DepthImageToLaserScan::use_point(const float new_value, const float old_val
   return shorter_check;
 }
 
+sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
+							     const sensor_msgs::CameraInfoConstPtr& info_msg)
+{
+  sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
+  convert_msg(depth_msg, info_msg, scan_msg);
+  return scan_msg;
+}
+
+sensor_msgs::LaserScanPtr convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
+					const sensor_msgs::CameraInfoConstPtr& info_msg)
+{
+  sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
+  convert_msg_f(depth_msg, info_msg, scan_msg);
+  return scan_msg;
+}
+
 bool DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
 	      const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg)
 {
@@ -118,7 +134,6 @@ bool DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_
   double angle_min = -angle_between_rays(center_ray, right_ray); // Negative because the laserscan message expects an opposite rotation of that from the depth image
   
   // Fill in laserscan message
-  //sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
   scan_msg->header = depth_msg->header;
   if(output_frame_id_.length() > 0){
     scan_msg->header.frame_id = output_frame_id_;
@@ -157,7 +172,6 @@ bool DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_
     throw std::runtime_error(ss.str());
   }
   
-  //return scan_msg;
   return true;
 }
 
@@ -183,7 +197,6 @@ bool DepthImageToLaserScan::convert_msg_f(const sensor_msgs::ImageConstPtr& dept
   float angle_min = -angle_between_rays_f(center_ray, right_ray); // Negative because the laserscan message expects an opposite rotation of that from the depth image
 
   // Fill in laserscan message
-  //sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
   scan_msg->header = depth_msg->header;
   if(output_frame_id_.length() > 0){
     scan_msg->header.frame_id = output_frame_id_;
@@ -223,7 +236,6 @@ bool DepthImageToLaserScan::convert_msg_f(const sensor_msgs::ImageConstPtr& dept
   }
 
   return true;
-  //return scan_msg;
 }
 
 void DepthImageToLaserScan::set_scan_time(const float scan_time){

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -42,7 +42,13 @@ DepthImageToLaserScan::~DepthImageToLaserScan(){
 }
 
 double DepthImageToLaserScan::magnitude_of_ray(const cv::Point3d& ray) const{
-  return sqrt(pow(ray.x, 2.0) + pow(ray.y, 2.0) + pow(ray.z, 2.0));
+  //return sqrt(pow(ray.x, 2.0) + pow(ray.y, 2.0) + pow(ray.z, 2.0));
+  // Optimizing compiler likes this much more
+  return sqrt(ray.x*ray.x + ray.y*ray.y + ray.z*ray.z);
+}
+
+float DepthImageToLaserScan::magnitude_of_ray_f(const cv::Point3f& ray) const{
+  return sqrtf(ray.x*ray.x + ray.y*ray.y + ray.z*ray.z);
 }
 
 double DepthImageToLaserScan::angle_between_rays(const cv::Point3d& ray1, const cv::Point3d& ray2) const{
@@ -50,6 +56,15 @@ double DepthImageToLaserScan::angle_between_rays(const cv::Point3d& ray1, const 
   double magnitude1 = magnitude_of_ray(ray1);
   double magnitude2 = magnitude_of_ray(ray2);;
   return acos(dot_product / (magnitude1 * magnitude2));
+}
+
+
+
+float DepthImageToLaserScan::angle_between_rays_f(const cv::Point3f& ray1, const cv::Point3f& ray2) const{
+  float dot_product = ray1.x*ray2.x + ray1.y*ray2.y + ray1.z*ray2.z;
+  float magnitude1 = magnitude_of_ray_f(ray1);
+  float magnitude2 = magnitude_of_ray_f(ray2);
+  return acosf(dot_product / (magnitude1 * magnitude2));
 }
 
 bool DepthImageToLaserScan::use_point(const float new_value, const float old_value, const float range_min, const float range_max) const{  
@@ -80,8 +95,9 @@ bool DepthImageToLaserScan::use_point(const float new_value, const float old_val
   return shorter_check;
 }
 
-sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
-	      const sensor_msgs::CameraInfoConstPtr& info_msg){
+bool DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
+	      const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg)
+{
   // Set camera model
   cam_model_.fromCameraInfo(info_msg);
   
@@ -102,7 +118,7 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
   double angle_min = -angle_between_rays(center_ray, right_ray); // Negative because the laserscan message expects an opposite rotation of that from the depth image
   
   // Fill in laserscan message
-  sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
+  //sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
   scan_msg->header = depth_msg->header;
   if(output_frame_id_.length() > 0){
     scan_msg->header.frame_id = output_frame_id_;
@@ -141,7 +157,73 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
     throw std::runtime_error(ss.str());
   }
   
-  return scan_msg;
+  //return scan_msg;
+  return true;
+}
+
+bool DepthImageToLaserScan::convert_msg_f(const sensor_msgs::ImageConstPtr& depth_msg,
+	      const sensor_msgs::CameraInfoConstPtr& info_msg, sensor_msgs::LaserScanPtr & scan_msg){
+  // Set camera model
+  cam_model_.fromCameraInfo(info_msg);
+
+  // Calculate angle_min and angle_max by measuring angles between the left ray, right ray, and optical center ray
+  cv::Point2f raw_pixel_left(0, cam_model_.cy());
+  cv::Point2f rect_pixel_left = cam_model_.rectifyPoint(raw_pixel_left);
+  cv::Point3f left_ray = cam_model_.projectPixelTo3dRay(rect_pixel_left);
+
+  cv::Point2f raw_pixel_right(depth_msg->width-1, cam_model_.cy());
+  cv::Point2f rect_pixel_right = cam_model_.rectifyPoint(raw_pixel_right);
+  cv::Point3f right_ray = cam_model_.projectPixelTo3dRay(rect_pixel_right);
+
+  cv::Point2f raw_pixel_center(cam_model_.cx(), cam_model_.cy());
+  cv::Point2f rect_pixel_center = cam_model_.rectifyPoint(raw_pixel_center);
+  cv::Point3f center_ray = cam_model_.projectPixelTo3dRay(rect_pixel_center);
+
+  float angle_max = angle_between_rays_f(left_ray, center_ray);
+  float angle_min = -angle_between_rays_f(center_ray, right_ray); // Negative because the laserscan message expects an opposite rotation of that from the depth image
+
+  // Fill in laserscan message
+  //sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
+  scan_msg->header = depth_msg->header;
+  if(output_frame_id_.length() > 0){
+    scan_msg->header.frame_id = output_frame_id_;
+  }
+  scan_msg->angle_min = angle_min;
+  scan_msg->angle_max = angle_max;
+  scan_msg->angle_increment = (scan_msg->angle_max - scan_msg->angle_min) / (depth_msg->width - 1);
+  scan_msg->time_increment = 0.0;
+  scan_msg->scan_time = scan_time_;
+  scan_msg->range_min = range_min_;
+  scan_msg->range_max = range_max_;
+
+  // Check scan_height vs image_height
+  if(scan_height_/2 > cam_model_.cy() || scan_height_/2 > depth_msg->height - cam_model_.cy()){
+    std::stringstream ss;
+    ss << "scan_height ( " << scan_height_ << " pixels) is too large for the image height.";
+    throw std::runtime_error(ss.str());
+  }
+
+  // Calculate and fill the ranges
+  uint32_t ranges_size = depth_msg->width;
+  scan_msg->ranges.assign(ranges_size, std::numeric_limits<float>::quiet_NaN());
+
+  if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
+  {
+	convert_f<uint16_t>(depth_msg, cam_model_, scan_msg, scan_height_);
+  }
+  else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1)
+  {
+	convert_f<float>(depth_msg, cam_model_, scan_msg, scan_height_);
+  }
+  else
+  {
+    std::stringstream ss;
+    ss << "Depth image has unsupported encoding: " << depth_msg->encoding;
+    throw std::runtime_error(ss.str());
+  }
+
+  return true;
+  //return scan_msg;
 }
 
 void DepthImageToLaserScan::set_scan_time(const float scan_time){

--- a/src/DepthImageToLaserScanROS_test.cpp
+++ b/src/DepthImageToLaserScanROS_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* 
+ * Author: Chad Rockey
+ */
+
+#include <depthimage_to_laserscan/DepthImageToLaserScanROS_test.h>
+
+using namespace depthimage_to_laserscan;
+  
+DepthImageToLaserScanROSTest::DepthImageToLaserScanROSTest(ros::NodeHandle& n, ros::NodeHandle& pnh):pnh_(pnh), it_(n), srv_(pnh) {
+  boost::mutex::scoped_lock lock(connect_mutex_);
+  
+  // Dynamic Reconfigure
+  dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig>::CallbackType f;
+  f = boost::bind(&DepthImageToLaserScanROSTest::reconfigureCb, this, _1, _2);
+  srv_.setCallback(f);
+  
+  // Lazy subscription to depth image topic
+  pub_ = n.advertise<sensor_msgs::LaserScan>("scan", 10, boost::bind(&DepthImageToLaserScanROSTest::connectCb, this, _1), boost::bind(&DepthImageToLaserScanROSTest::disconnectCb, this, _1));
+  pub_test_ = n.advertise<sensor_msgs::LaserScan>("scan_test", 10);
+}
+
+DepthImageToLaserScanROSTest::~DepthImageToLaserScanROSTest(){
+  sub_.shutdown();
+}
+
+
+
+void DepthImageToLaserScanROSTest::depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
+	      const sensor_msgs::CameraInfoConstPtr& info_msg){
+  try
+  {
+    sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(depth_msg, info_msg);
+    pub_.publish(scan_msg);
+
+    sensor_msgs::LaserScanPtr scan_test_msg = dtl_.convert_msg_f(depth_msg, info_msg);
+    pub_test_.publish(scan_test_msg);
+  }
+  catch (std::runtime_error& e)
+  {
+    ROS_ERROR_THROTTLE(1.0, "Could not convert depth image to laserscan: %s", e.what());
+  }
+}
+
+void DepthImageToLaserScanROSTest::connectCb(const ros::SingleSubscriberPublisher& pub) {
+  boost::mutex::scoped_lock lock(connect_mutex_);
+  if (!sub_ && pub_.getNumSubscribers() > 0) {
+    ROS_DEBUG("Connecting to depth topic.");
+    image_transport::TransportHints hints("raw", ros::TransportHints(), pnh_);
+    sub_ = it_.subscribeCamera("image", 10, &DepthImageToLaserScanROSTest::depthCb, this, hints);
+  }
+}
+
+void DepthImageToLaserScanROSTest::disconnectCb(const ros::SingleSubscriberPublisher& pub) {
+  boost::mutex::scoped_lock lock(connect_mutex_);
+  if (pub_.getNumSubscribers() == 0) {
+    ROS_DEBUG("Unsubscribing from depth topic.");
+    sub_.shutdown();
+  }
+}
+
+void DepthImageToLaserScanROSTest::reconfigureCb(depthimage_to_laserscan::DepthConfig& config, uint32_t level){
+    dtl_.set_scan_time(config.scan_time);
+    dtl_.set_range_limits(config.range_min, config.range_max);
+    dtl_.set_scan_height(config.scan_height);
+    dtl_.set_output_frame(config.output_frame_id);
+}
+
+int main(int argc, char **argv){
+  ros::init(argc, argv, "depthimage_to_laserscan");
+  ros::NodeHandle n;
+  ros::NodeHandle pnh("~");
+
+  depthimage_to_laserscan::DepthImageToLaserScanROSTest dtl(n, pnh);
+
+  ros::spin();
+
+  return 0;
+}


### PR DESCRIPTION
- most calculations use float instead of double (for NEON instruction set)
- column-order calculation, less 'atan2' calls
- added tests for performance comparison. 20x faster so far (tests were not so reliable)
- added test node to compare both scans from old and new processor