### PR TITLE
Whitespace cleanup in the tree.

### DIFF
--- a/include/depthimage_to_laserscan/DepthImageToLaserScan.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScan.h
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
@@ -44,7 +44,7 @@
 #include <math.h>
 
 namespace depthimage_to_laserscan
-{ 
+{
   class DepthImageToLaserScan
   {
   public:
@@ -53,121 +53,121 @@ namespace depthimage_to_laserscan
 
     /**
      * Converts the information in a depth image (sensor_msgs::Image) to a sensor_msgs::LaserScan.
-     * 
+     *
      * This function converts the information in the depth encoded image (UInt16 or Float32 encoding) into
      * a sensor_msgs::LaserScan as accurately as possible.  To do this, it requires the synchornized Image/CameraInfo
      * pair associated with the image.
-     * 
+     *
      * @param depth_msg UInt16 or Float32 encoded depth image.
      * @param info_msg CameraInfo associated with depth_msg
      * @return sensor_msgs::LaserScanPtr for the center row(s) of the depth image.
-     * 
+     *
      */
     sensor_msgs::LaserScanPtr convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
-					   const sensor_msgs::CameraInfoConstPtr& info_msg);
-    
+                                          const sensor_msgs::CameraInfoConstPtr& info_msg);
+
     /**
      * Sets the scan time parameter.
-     * 
-     * This function stores the desired value for scan_time.  In sensor_msgs::LaserScan, scan_time is defined as 
+     *
+     * This function stores the desired value for scan_time.  In sensor_msgs::LaserScan, scan_time is defined as
      * "time between scans [seconds]".  This value is not easily calculated from consquetive messages, and is thus
      * left to the user to set correctly.
-     * 
+     *
      * @param scan_time The value to use for outgoing sensor_msgs::LaserScan.
-     * 
+     *
      */
     void set_scan_time(const float scan_time);
-    
+
     /**
      * Sets the minimum and maximum range for the sensor_msgs::LaserScan.
-     * 
+     *
      * range_min is used to determine how close of a value to allow through when multiple radii correspond to the same
      * angular increment.  range_max is used to set the output message.
-     * 
+     *
      * @param range_min Minimum range to assign points to the laserscan, also minimum range to use points in the output scan.
      * @param range_max Maximum range to use points in the output scan.
-     * 
+     *
      */
     void set_range_limits(const float range_min, const float range_max);
-    
+
     /**
      * Sets the number of image rows to use in the output LaserScan.
-     * 
+     *
      * scan_height is the number of rows (pixels) to use in the output.  This will provide scan_height number of radii for each
      * angular increment.  The output scan will output the closest radius that is still not smaller than range_min.  This function
      * can be used to vertically compress obstacles into a single LaserScan.
-     * 
+     *
      * @param scan_height Number of pixels centered around the center of the image to compress into the LaserScan.
-     * 
+     *
      */
     void set_scan_height(const int scan_height);
-    
+
     /**
      * Sets the frame_id for the output LaserScan.
-     * 
+     *
      * Output frame_id for the LaserScan.  Will probably NOT be the same frame_id as the depth image.
      * Example: For OpenNI cameras, this should be set to 'camera_depth_frame' while the camera uses 'camera_depth_optical_frame'.
-     * 
+     *
      * @param output_frame_id Frame_id to use for the output sensor_msgs::LaserScan.
-     * 
+     *
      */
     void set_output_frame(const std::string output_frame_id);
 
   private:
     /**
      * Computes euclidean length of a cv::Point3d (as a ray from origin)
-     * 
+     *
      * This function computes the length of a cv::Point3d assumed to be a vector starting at the origin (0,0,0).
-     * 
+     *
      * @param ray The ray for which the magnitude is desired.
      * @return Returns the magnitude of the ray.
-     * 
+     *
      */
     double magnitude_of_ray(const cv::Point3d& ray) const;
 
     /**
      * Computes the angle between two cv::Point3d
-     * 
+     *
      * Computes the angle of two cv::Point3d assumed to be vectors starting at the origin (0,0,0).
      * Uses the following equation: angle = arccos(a*b/(|a||b|)) where a = ray1 and b = ray2.
-     * 
+     *
      * @param ray1 The first ray
      * @param ray2 The second ray
      * @return The angle between the two rays (in radians)
-     * 
+     *
      */
     double angle_between_rays(const cv::Point3d& ray1, const cv::Point3d& ray2) const;
-    
+
     /**
      * Determines whether or not new_value should replace old_value in the LaserScan.
-     * 
+     *
      * Uses the values of range_min, and range_max to determine if new_value is a valid point.  Then it determines if
      * new_value is 'more ideal' (currently shorter range) than old_value.
-     * 
+     *
      * @param new_value The current calculated range.
      * @param old_value The current range in the output LaserScan.
      * @param range_min The minimum acceptable range for the output LaserScan.
      * @param range_max The maximum acceptable range for the output LaserScan.
      * @return If true, insert new_value into the output LaserScan.
-     * 
+     *
      */
     bool use_point(const float new_value, const float old_value, const float range_min, const float range_max) const;
 
     /**
-    * Converts the depth image to a laserscan using the DepthTraits to assist.
-    * 
-    * This uses a method to inverse project each pixel into a LaserScan angular increment.  This method first projects the pixel
-    * forward into Cartesian coordinates, then calculates the range and angle for this point.  When multiple points coorespond to
-    * a specific angular measurement, then the shortest range is used.
-    * 
-    * @param depth_msg The UInt16 or Float32 encoded depth message.
-    * @param cam_model The image_geometry camera model for this image.
-    * @param scan_msg The output LaserScan.
-    * @param scan_height The number of vertical pixels to feed into each angular_measurement.
-    * 
-    */
+     * Converts the depth image to a laserscan using the DepthTraits to assist.
+     *
+     * This uses a method to inverse project each pixel into a LaserScan angular increment.  This method first projects the pixel
+     * forward into Cartesian coordinates, then calculates the range and angle for this point.  When multiple points coorespond to
+     * a specific angular measurement, then the shortest range is used.
+     *
+     * @param depth_msg The UInt16 or Float32 encoded depth message.
+     * @param cam_model The image_geometry camera model for this image.
+     * @param scan_msg The output LaserScan.
+     * @param scan_height The number of vertical pixels to feed into each angular_measurement.
+     *
+     */
     template<typename T>
-    void convert(const sensor_msgs::ImageConstPtr& depth_msg, const image_geometry::PinholeCameraModel& cam_model, 
+    void convert(const sensor_msgs::ImageConstPtr& depth_msg, const image_geometry::PinholeCameraModel& cam_model,
 		 const sensor_msgs::LaserScanPtr& scan_msg, const int& scan_height) const{
       // Use correct principal point from calibration
       float center_x = cam_model.cx();
@@ -177,7 +177,7 @@ namespace depthimage_to_laserscan
       double unit_scaling = depthimage_to_laserscan::DepthTraits<T>::toMeters( T(1) );
       float constant_x = unit_scaling / cam_model.fx();
       float constant_y = unit_scaling / cam_model.fy();
-      
+
       const T* depth_row = reinterpret_cast<const T*>(&depth_msg->data[0]);
       int row_step = depth_msg->step / sizeof(T);
 
@@ -185,23 +185,23 @@ namespace depthimage_to_laserscan
       depth_row += offset*row_step; // Offset to center of image
 
       for(int v = offset; v < offset+scan_height_; v++, depth_row += row_step){
-		for (int u = 0; u < (int)depth_msg->width; u++) // Loop over each pixel in row
-		{	
-		  T depth = depth_row[u];
-		  
-		  double r = depth; // Assign to pass through NaNs and Infs
-		  double th = -atan2((double)(u - center_x) * constant_x, unit_scaling); // Atan2(x, z), but depth divides out
-		  int index = (th - scan_msg->angle_min) / scan_msg->angle_increment;
-		  
-		  if (depthimage_to_laserscan::DepthTraits<T>::valid(depth)){ // Not NaN or Inf
-		    // Calculate in XYZ
-		    double x = (u - center_x) * depth * constant_x;
-		    double z = depthimage_to_laserscan::DepthTraits<T>::toMeters(depth);
-		    
-		    // Calculate actual distance
-		    r = sqrt(pow(x, 2.0) + pow(z, 2.0));
-		  }
-	  
+        for (int u = 0; u < (int)depth_msg->width; u++) // Loop over each pixel in row
+        {
+          T depth = depth_row[u];
+
+          double r = depth; // Assign to pass through NaNs and Infs
+          double th = -atan2((double)(u - center_x) * constant_x, unit_scaling); // Atan2(x, z), but depth divides out
+          int index = (th - scan_msg->angle_min) / scan_msg->angle_increment;
+
+          if (depthimage_to_laserscan::DepthTraits<T>::valid(depth)){ // Not NaN or Inf
+            // Calculate in XYZ
+            double x = (u - center_x) * depth * constant_x;
+            double z = depthimage_to_laserscan::DepthTraits<T>::toMeters(depth);
+
+            // Calculate actual distance
+            r = sqrt(pow(x, 2.0) + pow(z, 2.0));
+          }
+
 	  // Determine if this point should be used.
 	  if(use_point(r, scan_msg->ranges[index], scan_msg->range_min, scan_msg->range_max)){
 	    scan_msg->ranges[index] = r;
@@ -209,17 +209,15 @@ namespace depthimage_to_laserscan
 	}
       }
     }
-    
+
     image_geometry::PinholeCameraModel cam_model_; ///< image_geometry helper class for managing sensor_msgs/CameraInfo messages.
-    
+
     float scan_time_; ///< Stores the time between scans.
     float range_min_; ///< Stores the current minimum range to use.
     float range_max_; ///< Stores the current maximum range to use.
     int scan_height_; ///< Number of pixel rows to use when producing a laserscan from an area.
     std::string output_frame_id_; ///< Output frame_id for each laserscan.  This is likely NOT the camera's frame_id.
   };
-  
-  
-}; // depthimage_to_laserscan
+} // depthimage_to_laserscan
 
 #endif

--- a/include/depthimage_to_laserscan/DepthImageToLaserScan.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScan.h
@@ -63,8 +63,9 @@ namespace depthimage_to_laserscan
      * @return sensor_msgs::LaserScanPtr for the center row(s) of the depth image.
      *
      */
-    sensor_msgs::LaserScanPtr convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
-                                          const sensor_msgs::CameraInfoConstPtr& info_msg);
+    sensor_msgs::LaserScanPtr convert_msg(
+      const sensor_msgs::ImageConstPtr& depth_msg,
+      const sensor_msgs::CameraInfoConstPtr& info_msg);
 
     /**
      * Sets the scan time parameter.
@@ -167,8 +168,11 @@ namespace depthimage_to_laserscan
      *
      */
     template<typename T>
-    void convert(const sensor_msgs::ImageConstPtr& depth_msg, const image_geometry::PinholeCameraModel& cam_model,
-		 const sensor_msgs::LaserScanPtr& scan_msg, const int& scan_height) const{
+    void convert(
+      const sensor_msgs::ImageConstPtr& depth_msg,
+      const image_geometry::PinholeCameraModel& cam_model,
+      const sensor_msgs::LaserScanPtr& scan_msg,
+      const int& scan_height) const{
       // Use correct principal point from calibration
       float center_x = cam_model.cx();
       float center_y = cam_model.cy();

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
@@ -45,66 +45,64 @@
 #include <depthimage_to_laserscan/DepthImageToLaserScan.h>
 
 namespace depthimage_to_laserscan
-{ 
+{
   class DepthImageToLaserScanROS
   {
   public:
     DepthImageToLaserScanROS(ros::NodeHandle& n, ros::NodeHandle& pnh);
-    
+
     ~DepthImageToLaserScanROS();
 
   private:
     /**
      * Callback for image_transport
-     * 
+     *
      * Synchronized callback for depth image and camera info.  Publishes laserscan at the end of this callback.
-     * 
+     *
      * @param depth_msg Image provided by image_transport.
      * @param info_msg CameraInfo provided by image_transport.
-     * 
+     *
      */
     void depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
-		  const sensor_msgs::CameraInfoConstPtr& info_msg);
+                 const sensor_msgs::CameraInfoConstPtr& info_msg);
 
     /**
      * Callback that is called when there is a new subscriber.
-     * 
+     *
      * Will not subscribe to the image and camera_info until we have a subscriber for our LaserScan (lazy subscribing).
-     * 
+     *
      */
     void connectCb(const ros::SingleSubscriberPublisher& pub);
 
     /**
      * Callback called when a subscriber unsubscribes.
-     * 
+     *
      * If all current subscribers of our LaserScan stop listening, stop subscribing (lazy subscribing).
-     * 
+     *
      */
     void disconnectCb(const ros::SingleSubscriberPublisher& pub);
-    
+
     /**
      * Dynamic reconfigure callback.
-     * 
+     *
      * Callback that is used to set each of the parameters insde the DepthImageToLaserScan object.
-     * 
+     *
      * @param config Dynamic Reconfigure object.
      * @param level Dynamic Reconfigure level.
-     * 
+     *
      */
     void reconfigureCb(depthimage_to_laserscan::DepthConfig& config, uint32_t level);
-    
+
     ros::NodeHandle pnh_; ///< Private nodehandle used to generate the transport hints in the connectCb.
     image_transport::ImageTransport it_; ///< Subscribes to synchronized Image CameraInfo pairs.
     image_transport::CameraSubscriber sub_; ///< Subscriber for image_transport
     ros::Publisher pub_; ///< Publisher for output LaserScan messages
     dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig> srv_; ///< Dynamic reconfigure server
-    
+
     depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
-    
+
     boost::mutex connect_mutex_; ///< Prevents the connectCb and disconnectCb from being called until everything is initialized.
   };
-  
-  
-}; // depthimage_to_laserscan
+} // depthimage_to_laserscan
 
 #endif

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
@@ -49,7 +49,9 @@ namespace depthimage_to_laserscan
   class DepthImageToLaserScanROS
   {
   public:
-    DepthImageToLaserScanROS(ros::NodeHandle& n, ros::NodeHandle& pnh);
+    DepthImageToLaserScanROS(
+      ros::NodeHandle& n,
+      ros::NodeHandle& pnh);
 
     ~DepthImageToLaserScanROS();
 
@@ -63,8 +65,9 @@ namespace depthimage_to_laserscan
      * @param info_msg CameraInfo provided by image_transport.
      *
      */
-    void depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
-                 const sensor_msgs::CameraInfoConstPtr& info_msg);
+    void depthCb(
+      const sensor_msgs::ImageConstPtr& depth_msg,
+      const sensor_msgs::CameraInfoConstPtr& info_msg);
 
     /**
      * Callback that is called when there is a new subscriber.

--- a/include/depthimage_to_laserscan/depth_traits.h
+++ b/include/depthimage_to_laserscan/depth_traits.h
@@ -66,6 +66,6 @@ struct DepthTraits<float>
   }
 };
 
-} // namespace depth_image_proc
+} // namespace depthimage_to_laserscan
 
 #endif

--- a/include/depthimage_to_laserscan/depth_traits.h
+++ b/include/depthimage_to_laserscan/depth_traits.h
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -80,8 +80,9 @@ bool DepthImageToLaserScan::use_point(const float new_value, const float old_val
   return shorter_check;
 }
 
-sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::ImageConstPtr& depth_msg,
-	      const sensor_msgs::CameraInfoConstPtr& info_msg){
+sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(
+  const sensor_msgs::ImageConstPtr& depth_msg,
+  const sensor_msgs::CameraInfoConstPtr& info_msg){
   // Set camera model
   cam_model_.fromCameraInfo(info_msg);
 

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -27,14 +27,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
 #include <depthimage_to_laserscan/DepthImageToLaserScan.h>
 
 using namespace depthimage_to_laserscan;
-  
+
 DepthImageToLaserScan::DepthImageToLaserScan(){
 }
 
@@ -48,15 +48,15 @@ double DepthImageToLaserScan::magnitude_of_ray(const cv::Point3d& ray) const{
 double DepthImageToLaserScan::angle_between_rays(const cv::Point3d& ray1, const cv::Point3d& ray2) const{
   double dot_product = ray1.x*ray2.x + ray1.y*ray2.y + ray1.z*ray2.z;
   double magnitude1 = magnitude_of_ray(ray1);
-  double magnitude2 = magnitude_of_ray(ray2);;
+  double magnitude2 = magnitude_of_ray(ray2);
   return acos(dot_product / (magnitude1 * magnitude2));
 }
 
-bool DepthImageToLaserScan::use_point(const float new_value, const float old_value, const float range_min, const float range_max) const{  
+bool DepthImageToLaserScan::use_point(const float new_value, const float old_value, const float range_min, const float range_max) const{
   // Check for NaNs and Infs, a real number within our limits is more desirable than these.
   bool new_finite = std::isfinite(new_value);
   bool old_finite = std::isfinite(old_value);
-  
+
   // Infs are preferable over NaNs (more information)
   if(!new_finite && !old_finite){ // Both are not NaN or Inf.
     if(!isnan(new_value)){ // new is not NaN, so use it's +-Inf value.
@@ -64,17 +64,17 @@ bool DepthImageToLaserScan::use_point(const float new_value, const float old_val
     }
     return false; // Do not replace old_value
   }
-  
+
   // If not in range, don't bother
   bool range_check = range_min <= new_value && new_value <= range_max;
   if(!range_check){
     return false;
   }
-  
+
   if(!old_finite){ // New value is in range and finite, use it.
     return true;
   }
-  
+
   // Finally, if they are both numerical and new_value is closer than old_value, use new_value.
   bool shorter_check = new_value < old_value;
   return shorter_check;
@@ -84,23 +84,23 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
 	      const sensor_msgs::CameraInfoConstPtr& info_msg){
   // Set camera model
   cam_model_.fromCameraInfo(info_msg);
-  
+
   // Calculate angle_min and angle_max by measuring angles between the left ray, right ray, and optical center ray
   cv::Point2d raw_pixel_left(0, cam_model_.cy());
   cv::Point2d rect_pixel_left = cam_model_.rectifyPoint(raw_pixel_left);
   cv::Point3d left_ray = cam_model_.projectPixelTo3dRay(rect_pixel_left);
-  
+
   cv::Point2d raw_pixel_right(depth_msg->width-1, cam_model_.cy());
   cv::Point2d rect_pixel_right = cam_model_.rectifyPoint(raw_pixel_right);
   cv::Point3d right_ray = cam_model_.projectPixelTo3dRay(rect_pixel_right);
-  
+
   cv::Point2d raw_pixel_center(cam_model_.cx(), cam_model_.cy());
   cv::Point2d rect_pixel_center = cam_model_.rectifyPoint(raw_pixel_center);
   cv::Point3d center_ray = cam_model_.projectPixelTo3dRay(rect_pixel_center);
-  
+
   double angle_max = angle_between_rays(left_ray, center_ray);
   double angle_min = -angle_between_rays(center_ray, right_ray); // Negative because the laserscan message expects an opposite rotation of that from the depth image
-  
+
   // Fill in laserscan message
   sensor_msgs::LaserScanPtr scan_msg(new sensor_msgs::LaserScan());
   scan_msg->header = depth_msg->header;
@@ -114,7 +114,7 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
   scan_msg->scan_time = scan_time_;
   scan_msg->range_min = range_min_;
   scan_msg->range_max = range_max_;
-  
+
   // Check scan_height vs image_height
   if(scan_height_/2 > cam_model_.cy() || scan_height_/2 > depth_msg->height - cam_model_.cy()){
     std::stringstream ss;
@@ -125,7 +125,7 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
   // Calculate and fill the ranges
   uint32_t ranges_size = depth_msg->width;
   scan_msg->ranges.assign(ranges_size, std::numeric_limits<float>::quiet_NaN());
-  
+
   if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
   {
     convert<uint16_t>(depth_msg, cam_model_, scan_msg, scan_height_);
@@ -140,7 +140,7 @@ sensor_msgs::LaserScanPtr DepthImageToLaserScan::convert_msg(const sensor_msgs::
     ss << "Depth image has unsupported encoding: " << depth_msg->encoding;
     throw std::runtime_error(ss.str());
   }
-  
+
   return scan_msg;
 }
 

--- a/src/DepthImageToLaserScanNodelet.cpp
+++ b/src/DepthImageToLaserScanNodelet.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
@@ -50,7 +50,7 @@ private:
   {
     dtl.reset(new DepthImageToLaserScanROS(getNodeHandle(), getPrivateNodeHandle()));
   };
-  
+
   boost::shared_ptr<DepthImageToLaserScanROS> dtl;
 };
 
@@ -58,4 +58,3 @@ private:
 
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_DECLARE_CLASS(depthimage_to_laserscan, DepthImageToLaserScanNodelet, depthimage_to_laserscan::DepthImageToLaserScanNodelet, nodelet::Nodelet);
-

--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -35,7 +35,9 @@
 
 using namespace depthimage_to_laserscan;
 
-DepthImageToLaserScanROS::DepthImageToLaserScanROS(ros::NodeHandle& n, ros::NodeHandle& pnh):pnh_(pnh), it_(n), srv_(pnh) {
+DepthImageToLaserScanROS::DepthImageToLaserScanROS(
+  ros::NodeHandle& n,
+  ros::NodeHandle& pnh) : pnh_(pnh), it_(n), srv_(pnh) {
   boost::mutex::scoped_lock lock(connect_mutex_);
 
   // Dynamic Reconfigure
@@ -51,8 +53,9 @@ DepthImageToLaserScanROS::~DepthImageToLaserScanROS(){
   sub_.shutdown();
 }
 
-void DepthImageToLaserScanROS::depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
-                                       const sensor_msgs::CameraInfoConstPtr& info_msg){
+void DepthImageToLaserScanROS::depthCb(
+  const sensor_msgs::ImageConstPtr& depth_msg,
+  const sensor_msgs::CameraInfoConstPtr& info_msg){
   try
   {
     sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(depth_msg, info_msg);

--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -27,22 +27,22 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
 #include <depthimage_to_laserscan/DepthImageToLaserScanROS.h>
 
 using namespace depthimage_to_laserscan;
-  
+
 DepthImageToLaserScanROS::DepthImageToLaserScanROS(ros::NodeHandle& n, ros::NodeHandle& pnh):pnh_(pnh), it_(n), srv_(pnh) {
   boost::mutex::scoped_lock lock(connect_mutex_);
-  
+
   // Dynamic Reconfigure
   dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig>::CallbackType f;
   f = boost::bind(&DepthImageToLaserScanROS::reconfigureCb, this, _1, _2);
   srv_.setCallback(f);
-  
+
   // Lazy subscription to depth image topic
   pub_ = n.advertise<sensor_msgs::LaserScan>("scan", 10, boost::bind(&DepthImageToLaserScanROS::connectCb, this, _1), boost::bind(&DepthImageToLaserScanROS::disconnectCb, this, _1));
 }
@@ -51,10 +51,8 @@ DepthImageToLaserScanROS::~DepthImageToLaserScanROS(){
   sub_.shutdown();
 }
 
-
-
 void DepthImageToLaserScanROS::depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
-	      const sensor_msgs::CameraInfoConstPtr& info_msg){
+                                       const sensor_msgs::CameraInfoConstPtr& info_msg){
   try
   {
     sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(depth_msg, info_msg);

--- a/src/depthimage_to_laserscan.cpp
+++ b/src/depthimage_to_laserscan.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
@@ -37,9 +37,9 @@ int main(int argc, char **argv){
   ros::init(argc, argv, "depthimage_to_laserscan");
   ros::NodeHandle n;
   ros::NodeHandle pnh("~");
-  
+
   depthimage_to_laserscan::DepthImageToLaserScanROS dtl(n, pnh);
-  
+
   ros::spin();
 
   return 0;

--- a/test/DepthImageToLaserScanTest.cpp
+++ b/test/DepthImageToLaserScanTest.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* 
+/*
  * Author: Chad Rockey
  */
 
@@ -63,7 +63,7 @@ TEST(ConvertTest, setupLibrary)
   dtl_.set_scan_height(scan_height);
   const std::string output_frame = "camera_depth_frame";
   dtl_.set_output_frame(output_frame);
-  
+
   depth_msg_.reset(new sensor_msgs::Image);
   depth_msg_->header.seq = 42;
   depth_msg_->header.stamp.fromNSec(1234567890);
@@ -75,7 +75,7 @@ TEST(ConvertTest, setupLibrary)
   depth_msg_->step = depth_msg_->width*2; // 2 bytes per pixel
   uint16_t value = 0x0F;
   depth_msg_->data.assign(depth_msg_->height*depth_msg_->step, value); // Sets all values to 3.855m
-  
+
   info_msg_.reset(new sensor_msgs::CameraInfo);
   info_msg_->header = depth_msg_->header;
   info_msg_->height = depth_msg_->height;
@@ -95,9 +95,9 @@ TEST(ConvertTest, setupLibrary)
   info_msg_->P[5] = 570.3422241210938;
   info_msg_->P[6] = 235.5;
   info_msg_->P[10] = 1.0;
-  
+
   sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(depth_msg_, info_msg_);
-  
+
   // Test set variables
   EXPECT_EQ(scan_msg->scan_time, scan_time);
   EXPECT_EQ(scan_msg->range_min, range_min);
@@ -159,10 +159,10 @@ TEST(ConvertTest, testScanHeight)
       }
     }
   }
-  
+
   // Revert to 1 scan height
   dtl_.set_scan_height(1);
-  
+
 }
 
 // Test a randomly filled image and ensure all values are < range_min
@@ -170,15 +170,15 @@ TEST(ConvertTest, testScanHeight)
 TEST(ConvertTest, testRandom)
 {
   srand ( 8675309 ); // Set seed for repeatable tests
-  
+
   uint16_t* data = reinterpret_cast<uint16_t*>(&depth_msg_->data[0]);
   for(size_t i = 0; i < depth_msg_->width*depth_msg_->height; i++){
     data[i] = rand() % 500; // Distance between 0 and 0.5m
   }
-  
+
   // Convert
   sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(depth_msg_, info_msg_);
-  
+
   // Make sure all values are greater than or equal to range_min and less than or equal to range_max
   for(size_t i = 0; i < scan_msg->ranges.size(); i++){
     if(std::isfinite(scan_msg->ranges[i])){
@@ -196,15 +196,15 @@ TEST(ConvertTest, testNaN)
   float_msg->encoding = sensor_msgs::image_encodings::TYPE_32FC1;
   float_msg->step = float_msg->width*4; // 4 bytes per pixel
   float_msg->data.resize(float_msg->step * float_msg->height);
-  
+
   float* data = reinterpret_cast<float*>(&float_msg->data[0]);
   for(size_t i = 0; i < float_msg->width*float_msg->height; i++){
     data[i] = std::numeric_limits<float>::quiet_NaN();
   }
-  
+
   // Convert
   sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(float_msg, info_msg_);
-  
+
   // Make sure all values are NaN
   for(size_t i = 0; i < scan_msg->ranges.size(); i++){
     if(std::isfinite(scan_msg->ranges[i])){
@@ -221,15 +221,15 @@ TEST(ConvertTest, testPositiveInf)
   float_msg->encoding = sensor_msgs::image_encodings::TYPE_32FC1;
   float_msg->step = float_msg->width*4; // 4 bytes per pixel
   float_msg->data.resize(float_msg->step * float_msg->height);
-  
+
   float* data = reinterpret_cast<float*>(&float_msg->data[0]);
   for(size_t i = 0; i < float_msg->width*float_msg->height; i++){
     data[i] = std::numeric_limits<float>::infinity();
   }
-  
+
   // Convert
   sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(float_msg, info_msg_);
-  
+
   // Make sure most (> 80%) values are Inf
   size_t nan_count = 0;
   for(size_t i = 0; i < scan_msg->ranges.size(); i++){
@@ -241,7 +241,7 @@ TEST(ConvertTest, testPositiveInf)
       ADD_FAILURE() << "Negative value produced from postive infinity test.";
     }
   }
-  
+
   ASSERT_LE(nan_count, scan_msg->ranges.size() * 0.80);
 }
 
@@ -253,15 +253,15 @@ TEST(ConvertTest, testNegativeInf)
   float_msg->encoding = sensor_msgs::image_encodings::TYPE_32FC1;
   float_msg->step = float_msg->width*4; // 4 bytes per pixel
   float_msg->data.resize(float_msg->step * float_msg->height);
-  
+
   float* data = reinterpret_cast<float*>(&float_msg->data[0]);
   for(size_t i = 0; i < float_msg->width*float_msg->height; i++){
     data[i] = -std::numeric_limits<float>::infinity();
   }
-  
+
   // Convert
   sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(float_msg, info_msg_);
-  
+
   // Make sure most (> 80%) values are Inf
   size_t nan_count = 0;
   for(size_t i = 0; i < scan_msg->ranges.size(); i++){
@@ -273,13 +273,13 @@ TEST(ConvertTest, testNegativeInf)
       ADD_FAILURE() << "Postive value produced from negative infinity test.";
     }
   }
-  
+
   ASSERT_LE(nan_count, scan_msg->ranges.size() * 0.80);
 }
 
 
 // Run all the tests that were declared with TEST()
 int main(int argc, char **argv){
-testing::InitGoogleTest(&argc, argv);
-return RUN_ALL_TESTS();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Kill off all trailing whitespace, and fix up a few indentation
problems as well.  No functional change.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>