### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/DepthImageToLaserScanNodelet.cpp
+++ b/src/DepthImageToLaserScanNodelet.cpp
@@ -57,5 +57,5 @@ private:
 }
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(depthimage_to_laserscan, DepthImageToLaserScanNodelet, depthimage_to_laserscan::DepthImageToLaserScanNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(depthimage_to_laserscan::DepthImageToLaserScanNodelet, nodelet::Nodelet)
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions