### PR TITLE
Transform the laserscan data coordinate system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(image_geometry REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 include_directories(include)
 
@@ -20,6 +22,8 @@ ament_target_dependencies(DepthImageToLaserScan
   "image_geometry"
   "OpenCV"
   "sensor_msgs"
+  tf2
+  tf2_ros
 )
 
 add_library(DepthImageToLaserScanROS

--- a/cfg/Depth.cfg
+++ b/cfg/Depth.cfg
@@ -12,6 +12,7 @@ gen.add("scan_height",          int_t,    0,                                "Hei
 gen.add("scan_time",            double_t, 0,                                "Time for the entire scan sweep.",                                  0.033,  0.0, 1.0)
 gen.add("range_min",            double_t, 0,                                "Minimum reported range (in meters).",                              0.45,   0.0, 10.0)
 gen.add("range_max",            double_t, 0,                                "Maximum reported range (in meters).",                              10.0,   0.0, 10.0)
-gen.add("output_frame_id",      str_t,    0,                                "Output frame_id for the laserscan.",   "camera_depth_frame")
+gen.add("output_frame",         str_t,    0,                                "Output frame_id for the laserscan.",   "laser")
+gen.add("depth_optical_frame",  str_t,    0,                                "Output frame_id for the camera_depth_optical_frame.",   "camera_depth_optical_frame")
 
 exit(gen.generate(PACKAGE, "depthimage_to_laserscan", "Depth"))

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
   <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -170,3 +170,7 @@ void DepthImageToLaserScan::set_scan_height(const int scan_height){
 void DepthImageToLaserScan::set_output_frame(const std::string output_frame_id){
   output_frame_id_ = output_frame_id;
 }
+
+void DepthImageToLaserScan::set_depth_optical_frame(const std::string depth_optical_frame){
+  depth_optical_frame_ = depth_optical_frame;
+}


### PR DESCRIPTION
Transform the laserscan data coordinate system from camera_depth_optical_frame to the output frame. Solve the problem of laserscan data coordinate conversion when the camera is tilted.