### PR TITLE
[Windows][ros2] Export interfaces for Shared Lib on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(depthimage_to_laserscan)
+include(GenerateExportHeader)
+
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
@@ -21,6 +23,8 @@ ament_target_dependencies(DepthImageToLaserScan
   "OpenCV"
   "sensor_msgs"
 )
+generate_export_header(DepthImageToLaserScan EXPORT_FILE_NAME ${PROJECT_NAME}/DepthImageToLaserScan_export.h)
+target_include_directories(DepthImageToLaserScan PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
 add_library(DepthImageToLaserScanROS
   src/DepthImageToLaserScanROS.cpp
@@ -29,6 +33,8 @@ ament_target_dependencies(DepthImageToLaserScanROS
   "rclcpp"
 )
 target_link_libraries(DepthImageToLaserScanROS DepthImageToLaserScan)
+generate_export_header(DepthImageToLaserScanROS EXPORT_FILE_NAME ${PROJECT_NAME}/DepthImageToLaserScanROS_export.h)
+target_include_directories(DepthImageToLaserScanROS PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
 add_executable(depthimage_to_laserscan_node
   src/depthimage_to_laserscan.cpp
@@ -51,6 +57,11 @@ install(TARGETS DepthImageToLaserScan DepthImageToLaserScanROS
 install(TARGETS depthimage_to_laserscan_node
   DESTINATION lib/${PROJECT_NAME}
 )
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/DepthImageToLaserScan_export.h
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/DepthImageToLaserScanROS_export.h
+  DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/include/depthimage_to_laserscan/DepthImageToLaserScan.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScan.h
@@ -38,6 +38,7 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depthimage_to_laserscan/depth_traits.h>
+#include <depthimage_to_laserscan/DepthImageToLaserScan_export.h>
 #include <sstream>
 #include <limits.h>
 #include <math.h>
@@ -48,7 +49,7 @@
 
 namespace depthimage_to_laserscan
 { 
-  class DepthImageToLaserScan
+  class DEPTHIMAGETOLASERSCAN_EXPORT DepthImageToLaserScan
   {
   public:
     DepthImageToLaserScan();

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
@@ -40,10 +40,11 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 
 #include <depthimage_to_laserscan/DepthImageToLaserScan.h>
+#include <depthimage_to_laserscan/DepthImageToLaserScanROS_export.h>
 
 namespace depthimage_to_laserscan
 { 
-  class DepthImageToLaserScanROS
+  class DEPTHIMAGETOLASERSCANROS_EXPORT DepthImageToLaserScanROS
   {
   public:
     explicit DepthImageToLaserScanROS(rclcpp::Node::SharedPtr & node);


### PR DESCRIPTION
On Windows, for a shared library, the interfaces must be explicitly decorated by proper `dllimport` and `dllexport` usage. Otherwise, no imported library (.lib) will be generated for the downstream projects to consume at link time.

This pull request is to add the interface export in a portable way provided by `CMake` (instead of directly using MSVC specific `dllimport` and `dllexport`).

This is a rework for #39 