### PR TITLE
Foxy: clang-tidy fixes

### DIFF
--- a/include/depthimage_to_laserscan/DepthImageToLaserScan.hpp
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScan.hpp
@@ -37,8 +37,8 @@
 #include <cmath>
 #include <string>
 
-#include <depthimage_to_laserscan/depth_traits.hpp>
 #include <depthimage_to_laserscan/DepthImageToLaserScan_export.h>
+#include <depthimage_to_laserscan/depth_traits.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <opencv2/core/core.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -181,7 +181,7 @@ namespace depthimage_to_laserscan
       const T* depth_row = reinterpret_cast<const T*>(&depth_msg->data[0]);
       int row_step = depth_msg->step / sizeof(T);
 
-      int offset = static_cast<int>(cam_model.cy() - scan_height / 2);
+      int offset = static_cast<int>(cam_model.cy() - static_cast<double>(scan_height) / 2.0);
       depth_row += offset*row_step; // Offset to center of image
       for(int v = offset; v < offset+scan_height_; v++, depth_row += row_step){
         for(uint32_t u = 0; u < depth_msg->width; u++){ // Loop over each pixel in row
@@ -216,6 +216,6 @@ namespace depthimage_to_laserscan
     int scan_height_; ///< Number of pixel rows to use when producing a laserscan from an area.
     std::string output_frame_id_; ///< Output frame_id for each laserscan.  This is likely NOT the camera's frame_id.
   };
-} // depthimage_to_laserscan
+}  // namespace depthimage_to_laserscan
 
 #endif

--- a/include/depthimage_to_laserscan/DepthImageToLaserScan.hpp
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScan.hpp
@@ -50,7 +50,25 @@ namespace depthimage_to_laserscan
   class DEPTHIMAGETOLASERSCAN_EXPORT DepthImageToLaserScan final
   {
   public:
-    DepthImageToLaserScan();
+    /**
+     * Constructor.
+     *
+     * @param scan_time The value to use for outgoing sensor_msgs::msg::LaserScan.  In sensor_msgs::msg::LaserScan,
+     *                  scan_time is defined as "time between scans [seconds]".  This value is not easily calculated
+     *                  from consecutive messages, and is thus left to the user to set correctly.
+     * @param range_min The minimum range for the sensor_msgs::msg::LaserScan.  This is used to determine how close
+     *                  of a value to allow through when multiple radii correspond to the same angular increment.
+     * @param range_max The maximum range for the sensor_msgs::msg::LaserScan.  This is used to set the output message.
+     * @param scan_height The number of rows (pixels) to use in the output.  This will provide scan_height number of
+     *                    radii for each angular increment.  The output scan will output the closest radius that is
+     *                    still not smaller than range_min.  This can be used to vertically compress obstacles into
+     *                    a single LaserScan.
+     * @param frame_id The output frame_id for the LaserScan.  This will probably NOT be the same frame_id as the
+     *                 depth image.  Example: For OpenNI cameras, this should be set to 'camera_depth_frame' while
+     *                 the camera uses 'camera_depth_optical_frame'.
+     *
+     */
+    explicit DepthImageToLaserScan(float scan_time, float range_min, float range_max, int scan_height, const std::string& frame_id);
     ~DepthImageToLaserScan();
 
     /**
@@ -67,53 +85,6 @@ namespace depthimage_to_laserscan
      */
     sensor_msgs::msg::LaserScan::UniquePtr convert_msg(const sensor_msgs::msg::Image::ConstSharedPtr& depth_msg,
                                                        const sensor_msgs::msg::CameraInfo::ConstSharedPtr& info_msg);
-
-    /**
-     * Sets the scan time parameter.
-     *
-     * This function stores the desired value for scan_time.  In sensor_msgs::msg::LaserScan, scan_time is defined as
-     * "time between scans [seconds]".  This value is not easily calculated from consecutive messages, and is thus
-     * left to the user to set correctly.
-     *
-     * @param scan_time The value to use for outgoing sensor_msgs::msg::LaserScan.
-     *
-     */
-    void set_scan_time(const float scan_time);
-
-    /**
-     * Sets the minimum and maximum range for the sensor_msgs::msg::LaserScan.
-     *
-     * range_min is used to determine how close of a value to allow through when multiple radii correspond to the same
-     * angular increment.  range_max is used to set the output message.
-     *
-     * @param range_min Minimum range to assign points to the laserscan, also minimum range to use points in the output scan.
-     * @param range_max Maximum range to use points in the output scan.
-     *
-     */
-    void set_range_limits(const float range_min, const float range_max);
-
-    /**
-     * Sets the number of image rows to use in the output LaserScan.
-     *
-     * scan_height is the number of rows (pixels) to use in the output.  This will provide scan_height number of radii for each
-     * angular increment.  The output scan will output the closest radius that is still not smaller than range_min.  This function
-     * can be used to vertically compress obstacles into a single LaserScan.
-     *
-     * @param scan_height Number of pixels centered around the center of the image to compress into the LaserScan.
-     *
-     */
-    void set_scan_height(const int scan_height);
-
-    /**
-     * Sets the frame_id for the output LaserScan.
-     *
-     * Output frame_id for the LaserScan.  Will probably NOT be the same frame_id as the depth image.
-     * Example: For OpenNI cameras, this should be set to 'camera_depth_frame' while the camera uses 'camera_depth_optical_frame'.
-     *
-     * @param output_frame_id Frame_id to use for the output sensor_msgs::msg::LaserScan.
-     *
-     */
-    void set_output_frame(const std::string output_frame_id);
 
   private:
     /**

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.hpp
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.hpp
@@ -34,6 +34,8 @@
 #ifndef DEPTH_IMAGE_TO_LASERSCAN_ROS
 #define DEPTH_IMAGE_TO_LASERSCAN_ROS
 
+#include <memory>
+
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -71,7 +73,7 @@ namespace depthimage_to_laserscan
 
     rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_pub_;
 
-    depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
+    std::unique_ptr<depthimage_to_laserscan::DepthImageToLaserScan> dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
   };
 }  // namespace depthimage_to_laserscan
 

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.hpp
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.hpp
@@ -49,7 +49,7 @@ namespace depthimage_to_laserscan
   public:
     explicit DepthImageToLaserScanROS(const rclcpp::NodeOptions & options);
 
-    ~DepthImageToLaserScanROS();
+    ~DepthImageToLaserScanROS() override;
 
   private:
     /**
@@ -73,6 +73,6 @@ namespace depthimage_to_laserscan
 
     depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
   };
-} // depthimage_to_laserscan
+}  // namespace depthimage_to_laserscan
 
 #endif

--- a/include/depthimage_to_laserscan/depth_traits.hpp
+++ b/include/depthimage_to_laserscan/depth_traits.hpp
@@ -35,6 +35,8 @@
 #define DEPTH_IMAGE_TO_LASERSCAN_DEPTH_TRAITS
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <limits>
 #include <vector>
 
@@ -48,8 +50,8 @@ struct DepthTraits<uint16_t>
 {
   static inline bool valid(uint16_t depth) { return depth != 0; }
   static inline float toMeters(uint16_t depth) { return depth * 0.001f; } // originally mm
-  static inline uint16_t fromMeters(float depth) { return (depth * 1000.0f) + 0.5f; }
-  static inline void initializeBuffer(std::vector<uint8_t>&) {} // Already zero-filled
+  static inline uint16_t fromMeters(float depth) { return std::lround(depth * 1000.0f); }
+  static inline void initializeBuffer(std::vector<uint8_t>& buffer) {(void)buffer;} // Already zero-filled
 };
 
 template<>

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -71,10 +71,7 @@ bool DepthImageToLaserScan::use_point(const float new_value, const float old_val
 
   // Infs are preferable over NaNs (more information)
   if(!new_finite && !old_finite){ // Both are not NaN or Inf.
-    if(!std::isnan(new_value)){ // new is not NaN, so use it's +-Inf value.
-      return true;
-    }
-    return false; // Do not replace old_value
+    return !std::isnan(new_value); // new is not NaN, so use it's +-Inf value.
   }
 
   // If not in range, don't bother
@@ -128,7 +125,7 @@ sensor_msgs::msg::LaserScan::UniquePtr DepthImageToLaserScan::convert_msg(const 
   scan_msg->range_max = range_max_;
 
   // Check scan_height vs image_height
-  if(scan_height_/2 > cam_model_.cy() || scan_height_/2 > depth_msg->height - cam_model_.cy()){
+  if(static_cast<double>(scan_height_)/2.0 > cam_model_.cy() || static_cast<double>(scan_height_)/2.0 > depth_msg->height - cam_model_.cy()){
     std::stringstream ss;
     ss << "scan_height ( " << scan_height_ << " pixels) is too large for the image height.";
     throw std::runtime_error(ss.str());

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -47,7 +47,8 @@
 
 namespace depthimage_to_laserscan {
 
-DepthImageToLaserScan::DepthImageToLaserScan(){
+DepthImageToLaserScan::DepthImageToLaserScan(float scan_time, float range_min, float range_max, int scan_height, const std::string& frame_id)
+: scan_time_(scan_time), range_min_(range_min), range_max_(range_max), scan_height_(scan_height), output_frame_id_(frame_id){
 }
 
 DepthImageToLaserScan::~DepthImageToLaserScan(){
@@ -148,23 +149,6 @@ sensor_msgs::msg::LaserScan::UniquePtr DepthImageToLaserScan::convert_msg(const 
   }
 
   return scan_msg;
-}
-
-void DepthImageToLaserScan::set_scan_time(const float scan_time){
-  scan_time_ = scan_time;
-}
-
-void DepthImageToLaserScan::set_range_limits(const float range_min, const float range_max){
-  range_min_ = range_min;
-  range_max_ = range_max;
-}
-
-void DepthImageToLaserScan::set_scan_height(const int scan_height){
-  scan_height_ = scan_height;
-}
-
-void DepthImageToLaserScan::set_output_frame(const std::string output_frame_id){
-  output_frame_id_ = output_frame_id;
 }
 
 }  // namespace depthimage_to_laserscan

--- a/test/DepthImageToLaserScanTest.cpp
+++ b/test/DepthImageToLaserScanTest.cpp
@@ -31,8 +31,9 @@
  * Author: Chad Rockey
  */
 
-#include <limits>
 #include <cmath>
+#include <limits>
+#include <random>
 
 // Bring in my package's API, which is what I'm testing
 #include <depthimage_to_laserscan/DepthImageToLaserScan.hpp>
@@ -85,7 +86,7 @@ TEST(ConvertTest, setupLibrary)
   info_msg_->roi.y_offset = 0;
   info_msg_->roi.height = 0;
   info_msg_->roi.width = 0;
-  info_msg_->roi.do_rectify = 0;
+  info_msg_->roi.do_rectify = false;
   info_msg_->d.resize(5); // All 0, no distortion
   info_msg_->k[0] = 570.3422241210938;
   info_msg_->k[1] = 0.0;
@@ -154,7 +155,7 @@ TEST(ConvertTest, testScanHeight)
 
     dtl_.set_scan_height(scan_height);
 
-    int offset = (int)(info_msg_->k[5]-scan_height/2);
+    int offset = static_cast<int>(info_msg_->k[5]-static_cast<double>(scan_height)/2.0);
     data += offset*row_step; // Offset to center of image
 
     for(int v = 0; v < scan_height; v++, data += row_step){
@@ -190,11 +191,12 @@ TEST(ConvertTest, testScanHeight)
 // (range_max is currently violated to fill the messages)
 TEST(ConvertTest, testRandom)
 {
-  srand ( 8675309 ); // Set seed for repeatable tests
+  std::mt19937 rng(8675309);  // Set seed for repeatable tests
+  std::uniform_int_distribution<uint16_t> uniform_int(0, 500);
 
   uint16_t* data = reinterpret_cast<uint16_t*>(&depth_msg_->data[0]);
   for(size_t i = 0; i < depth_msg_->width*depth_msg_->height; i++){
-    data[i] = rand() % 500; // Distance between 0 and 0.5m
+    data[i] = uniform_int(rng);
   }
 
   // Convert


### PR DESCRIPTION
I ran clang-tidy on the codebase, and it pointed out a bunch of small things to be fixed.  One of the fixes in here actually changes the API, so this should be targeted at Foxy (I'll make a separate branch for it presently).  Other than that, the rest of the changes should be fairly innocuous.