### PR TITLE
fix param file

### DIFF
--- a/cfg/param.yaml
+++ b/cfg/param.yaml
@@ -4,4 +4,4 @@ depthimage_to_laserscan:
     range_min: 0.45
     range_max: 10.0
     scan_height: 1
-    output_frame: "camera_depth_optical_frame"
+    output_frame: "camera_depth_frame"

--- a/cfg/param.yaml
+++ b/cfg/param.yaml
@@ -1,4 +1,4 @@
-depthimage_to_laserscan_node:
+depthimage_to_laserscan:
   ros__parameters:
     scan_time: 0.033
     range_min: 0.45

--- a/cfg/param.yaml
+++ b/cfg/param.yaml
@@ -1,7 +1,7 @@
-depthimage_to_laserscan:
+depthimage_to_laserscan_node:
   ros__parameters:
     scan_time: 0.033
     range_min: 0.45
     range_max: 10.0
     scan_height: 1
-    output_frame: camera_depth_optical_frame
+    output_frame: "camera_depth_optical_frame"

--- a/launch/depthimage_to_laserscan-launch.py
+++ b/launch/depthimage_to_laserscan-launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
         Node(
             package='depthimage_to_laserscan',
             executable='depthimage_to_laserscan_node',
-            name='depthimage_to_laserscan_node',
+            name='depthimage_to_laserscan',
             remappings=[('depth', '/camera/depth/image_rect_raw'),
                         ('depth_camera_info', '/camera/depth/camera_info')],
             parameters=[param_config])


### PR DESCRIPTION
The namespace of the parameter file had to be corrected to "**depthimage_to_laserscan_node**" so that all parameters can be read from the yaml file.