### PR TITLE
Fix for Quality of Service (QoS) settings incompatibility between Gazebo plugin and depthimage_to_laserscan package

### DIFF
--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -47,7 +47,11 @@
 namespace depthimage_to_laserscan{
 
 DepthImageToLaserScanROS::DepthImageToLaserScanROS(const rclcpp::NodeOptions & options): rclcpp::Node("depthimage_to_laserscan", options){
-  auto qos = rclcpp:: SystemDefaultsQoS();
+  // auto qos = rclcpp:: SystemDefaultsQoS(); // Changed because depth camera publisher does not use RELIABLE (default) QoS but BestEffort
+  auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+qos.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+
+
   cam_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>("depth_camera_info", qos,
       std::bind(
         &DepthImageToLaserScanROS::infoCb, this,
@@ -96,3 +100,4 @@ void DepthImageToLaserScanROS::depthCb(const sensor_msgs::msg::Image::SharedPtr 
 }  // namespace depthimage_to_laserscan
 
 RCLCPP_COMPONENTS_REGISTER_NODE(depthimage_to_laserscan::DepthImageToLaserScanROS)
+


### PR DESCRIPTION
Hello Maintainers,

I've recently encountered **an issue** while using the depthimage_to_laserscan package in the context of the ROS2 Galactic distribution: https://answers.ros.org/question/417736/depth_image_to_laserscan-not-publishing-to-kinect_scan-topic-in-ros2-galactic/?answer=417845#post-id-417845

 The problem arose due to a **mismatch in the Quality of Service (QoS)** settings between the Gazebo depth camera plugin publisher and the subscriber in the depthimage_to_laserscan package.

The Gazebo plugin uses a Best Effort QoS policy for publishing depth camera images, while the depthimage_to_laserscan package, by default, subscribes with a Reliable QoS policy. This mismatch was causing the depthimage_to_laserscan package to not receive any messages from the Gazebo publisher.

To fix this issue, **I modified the QoS policy used by the depthimage_to_laserscan subscriber to Best Effort.** This change aligns the QoS policy of the depthimage_to_laserscan package with that of the Gazebo publisher, thereby enabling successful communication.

I believe this fix is important as it allows the depthimage_to_laserscan package to function correctly with standard Gazebo plugins in newer ROS2 distributions like Galactic. This will benefit many developers and researchers who rely on this functionality for their projects and increase the overall compatibility of the package with the ROS2 ecosystem.

Thank you for considering my pull request. I look forward to your feedback.

