### PR TITLE
Quantile filtering new

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ Parameters
 * `range_min` (float) - The minimum distance in meters a projected point should be.  Points closer than this are discarded.  Defaults to 0.45 meters.
 * `range_max` (float) - The maximum distance in meters a projected point should be.  Points further than this are discarded.  Defaults to 10.0 meters.
 * `scan_height` (int) - The row from the depth image to use for the laser projection.  Defaults to 1.
+* `quantile_value` (float) - The quantile value to use when computing the distance for each column. Defaults to 0.0 (use minimum value in each column).
 * `output_frame` (string) - The frame id to publish in the LaserScan message.  Defaults to "camera_depth_frame".

--- a/cfg/param.yaml
+++ b/cfg/param.yaml
@@ -4,4 +4,5 @@ depthimage_to_laserscan:
     range_min: 0.45
     range_max: 10.0
     scan_height: 1
+    quantile_value: 0.0
     output_frame: "camera_depth_frame"

--- a/src/DepthImageToLaserScan.cpp
+++ b/src/DepthImageToLaserScan.cpp
@@ -49,9 +49,9 @@ namespace depthimage_to_laserscan
 
 DepthImageToLaserScan::DepthImageToLaserScan(
   float scan_time, float range_min, float range_max,
-  int scan_height, const std::string & frame_id)
+  int scan_height, float quantile_value, const std::string & frame_id)
 : scan_time_(scan_time), range_min_(range_min), range_max_(range_max), scan_height_(scan_height),
-  output_frame_id_(frame_id)
+  quantile_value_(quantile_value), output_frame_id_(frame_id)
 {
 }
 
@@ -156,9 +156,9 @@ sensor_msgs::msg::LaserScan::UniquePtr DepthImageToLaserScan::convert_msg(
   scan_msg->ranges.assign(ranges_size, std::numeric_limits<float>::quiet_NaN());
 
   if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
-    convert<uint16_t>(depth_msg, cam_model_, scan_msg, scan_height_);
+    convert<uint16_t>(depth_msg, cam_model_, scan_msg, scan_height_, quantile_value_);
   } else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1) {
-    convert<float>(depth_msg, cam_model_, scan_msg, scan_height_);
+    convert<float>(depth_msg, cam_model_, scan_msg, scan_height_, quantile_value_);
   } else {
     std::stringstream ss;
     ss << "Depth image has unsupported encoding: " << depth_msg->encoding;

--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -69,10 +69,12 @@ DepthImageToLaserScanROS::DepthImageToLaserScanROS(const rclcpp::NodeOptions & o
 
   int scan_height = this->declare_parameter("scan_height", 1);
 
+  float quantile_value = this->declare_parameter("quantile_value", 0.0);
+
   std::string output_frame = this->declare_parameter("output_frame", "camera_depth_frame");
 
   dtl_ = std::make_unique<depthimage_to_laserscan::DepthImageToLaserScan>(
-    scan_time, range_min, range_max, scan_height, output_frame);
+    scan_time, range_min, range_max, scan_height, quantile_value, output_frame);
 }
 
 DepthImageToLaserScanROS::~DepthImageToLaserScanROS()


### PR DESCRIPTION
Currently the minimum value of each column in the depthimage was used to calculate the distance values. 

When dealing with noisy data it is benefitial to use e.g. the 10% quantile instead of the minimum value. This way we still get accurate data but ignore noise/outliers. 

The parameter `quantile_value` controls which quantile should be used. 
- Setting it to `0.0` will have the effect of using the minimum value of each column (the current behavior and default value). 
- Setting it to `0.5` will use the median of each column. 
- I got quite good results with using a `quantile_value` of around `0.1`. This way a lot of noise/outliers was removed, but the laserscan data still contained obstacles, even if they only covered a small part (>10%) of the `scan_height`. 